### PR TITLE
tolerance for floating point calcs

### DIFF
--- a/tests/testthat/test-bootstrap.R
+++ b/tests/testthat/test-bootstrap.R
@@ -35,9 +35,9 @@ bootmatrix_control <- as.matrix(read.csv("../fixtures/boostrapmatrix1.csv", row.
 # Testing
 
 test_that("Seminr performs the bootstrapping correctly", {
-  expect_equal(bootmatrix[,1], bootmatrix_control[,1])
-  expect_equal(bootmatrix[,2], bootmatrix_control[,2])
-  expect_equal(bootmatrix[,3], bootmatrix_control[,3])
+  expect_equal(bootmatrix[,1], bootmatrix_control[,1], tolerance = 0.00001)
+  expect_equal(bootmatrix[,2], bootmatrix_control[,2], tolerance = 0.00001)
+  expect_equal(bootmatrix[,3], bootmatrix_control[,3], tolerance = 0.00001)
 })
 
 context("SEMinR correctly bootstraps the interaction model\n")
@@ -84,9 +84,9 @@ bootmatrix_control <- as.matrix(read.csv("../fixtures/boostrapmatrix2.csv", row.
 # Testing
 
 test_that("Seminr performs the bootstrapping correctly", {
-  expect_equal(bootmatrix[,1], bootmatrix_control[,1])
-  expect_equal(bootmatrix[,2], bootmatrix_control[,2])
-  expect_equal(bootmatrix[,3], bootmatrix_control[,3])
+  expect_equal(bootmatrix[,1], bootmatrix_control[,1], tolerance = 0.00001)
+  expect_equal(bootmatrix[,2], bootmatrix_control[,2], tolerance = 0.00001)
+  expect_equal(bootmatrix[,3], bootmatrix_control[,3], tolerance = 0.00001)
 })
 
 context("SEMinR correctly bootstraps the model weights - composite measurement mode\n")
@@ -126,9 +126,9 @@ bootmatrix_control <- as.matrix(read.csv("../fixtures/boot_weights.csv", row.nam
 # Testing
 
 test_that("Seminr performs the bootstrapping correctly", {
-  expect_equal(bootmatrix[,1], bootmatrix_control[,1])
-  expect_equal(bootmatrix[,2], bootmatrix_control[,2])
-  expect_equal(bootmatrix[,3], bootmatrix_control[,3])
+  expect_equal(bootmatrix[,1], bootmatrix_control[,1], tolerance = 0.00001)
+  expect_equal(bootmatrix[,2], bootmatrix_control[,2], tolerance = 0.00001)
+  expect_equal(bootmatrix[,3], bootmatrix_control[,3], tolerance = 0.00001)
 })
 
 context("SEMinR correctly bootstraps the model loadings - factor measurement mode\n")
@@ -168,9 +168,9 @@ bootmatrix_control <- as.matrix(read.csv("../fixtures/boot_loadings.csv", row.na
 # Testing
 
 test_that("Seminr performs the bootstrapping correctly", {
-  expect_equal(bootmatrix[,1], bootmatrix_control[,1])
-  expect_equal(bootmatrix[,2], bootmatrix_control[,2])
-  expect_equal(bootmatrix[,3], bootmatrix_control[,3])
+  expect_equal(bootmatrix[,1], bootmatrix_control[,1], tolerance = 0.00001)
+  expect_equal(bootmatrix[,2], bootmatrix_control[,2], tolerance = 0.00001)
+  expect_equal(bootmatrix[,3], bootmatrix_control[,3], tolerance = 0.00001)
 })
 
 
@@ -190,7 +190,7 @@ bootmatrix_control <- as.matrix(read.csv("../fixtures/boot_HTMT.csv", row.names 
 # Testing
 
 test_that("Seminr performs the bootstrapping correctly", {
-  expect_equal(bootmatrix[,1], bootmatrix_control[,1])
-  expect_equal(bootmatrix[,2], bootmatrix_control[,2])
-  expect_equal(bootmatrix[,3], bootmatrix_control[,3])
+  expect_equal(bootmatrix[,1], bootmatrix_control[,1], tolerance = 0.00001)
+  expect_equal(bootmatrix[,2], bootmatrix_control[,2], tolerance = 0.00001)
+  expect_equal(bootmatrix[,3], bootmatrix_control[,3], tolerance = 0.00001)
 })

--- a/tests/testthat/test-consistent.R
+++ b/tests/testthat/test-consistent.R
@@ -34,7 +34,7 @@ rho_control <- as.matrix(read.csv("../fixtures/rho1.csv", row.names = 1))
 # Testing
 
 test_that("Seminr estimates rhoA correctly\n", {
-  expect_equal(rho, rho_control)
+  expect_equal(rho, rho_control, tolerance = 0.00001)
 })
 
 context("SEMinR correctly estimates rhoA for the interaction model\n")
@@ -80,7 +80,7 @@ rho_control <- as.matrix(read.csv("../fixtures/rho2.csv", row.names = 1))
 # Testing
 
 test_that("Seminr estimates rho_A correctly\n", {
-  expect_equal(rho, rho_control)
+  expect_equal(rho, rho_control, tolerance = 0.00001)
 })
 
 context("SEMinR correctly estimates PLSc path coefficients, rsquared and loadings for the simple model\n")
@@ -126,15 +126,15 @@ rSquared_control <- as.matrix(read.csv("../fixtures/rsquaredplsc.csv", row.names
 # Testing
 
 test_that("Seminr estimates PLSc path coefficients correctly\n", {
-  expect_equal(path_coef, path_coef_control)
+  expect_equal(path_coef, path_coef_control, tolerance = 0.00001)
 })
 
 test_that("Seminr estimates PLSc loadings correctly\n", {
-  expect_equal(loadings, loadings_control)
+  expect_equal(loadings, loadings_control, tolerance = 0.00001)
 })
 
 test_that("Seminr estimates rsquared  correctly\n", {
   # remove BIC for now
   #expect_equal(rSquared, rSquared_control)
-  expect_equal(rSquared[1:2,], rSquared_control[1:2,])
+  expect_equal(rSquared[1:2,], rSquared_control[1:2,], tolerance = 0.00001)
 })

--- a/tests/testthat/test-inner_weighting.R
+++ b/tests/testthat/test-inner_weighting.R
@@ -42,15 +42,15 @@ weight_control <- as.matrix(read.csv("../fixtures/inner_weights_weights.csv", ro
 # Testing
 
 test_that("Seminr estimates the loadings and path coefficients correctly", {
-  expect_equal(coefficients[,4], coefficients_control[,4])
+  expect_equal(coefficients[,4], coefficients_control[,4], tolerance = 0.00001)
 })
 
 test_that("Seminr estimates the construct scores correctly", {
-  expect_equal(construct_scores[,1:4], construct_scores_control[,1:4])
+  expect_equal(construct_scores[,1:4], construct_scores_control[,1:4], tolerance = 0.00001)
 })
 
 test_that("Seminr estimates the outer weights correctly", {
-  expect_equal(weight, weight_control)
+  expect_equal(weight, weight_control, tolerance = 0.00001)
 })
 
 context("SEMinR correctly estimates the model using factorial scheme\n")
@@ -97,13 +97,13 @@ weight_control <- as.matrix(read.csv("../fixtures/factorial_weights.csv", row.na
 # Testing
 
 test_that("Seminr estimates the loadings and path coefficients correctly", {
-  expect_equal(coefficients[,4], coefficients_control[,4])
+  expect_equal(coefficients[,4], coefficients_control[,4], tolerance = 0.00001)
 })
 
 test_that("Seminr estimates the  scores correctly", {
-  expect_equal(construct_scores[,1:4], construct_scores_control[,1:4])
+  expect_equal(construct_scores[,1:4], construct_scores_control[,1:4], tolerance = 0.00001)
 })
 
 test_that("Seminr estimates the outer weights correctly", {
-  expect_equal(weight, weight_control)
+  expect_equal(weight, weight_control, tolerance = 0.00001)
 })

--- a/tests/testthat/test-metric.R
+++ b/tests/testthat/test-metric.R
@@ -38,6 +38,6 @@ rsquared_control <- as.matrix(read.csv("../fixtures/rsquared1.csv", row.names = 
 
 test_that("Seminr estimates the Rsquared correctly", {
   # Remove BIC for now
-  expect_equal(rsquared[1:2,1], rsquared_control[1:2,1])
+  expect_equal(rsquared[1:2,1], rsquared_control[1:2,1], tolerance = 0.00001)
 })
 

--- a/tests/testthat/test-output.r
+++ b/tests/testthat/test-output.r
@@ -48,15 +48,15 @@ weight_control <- as.matrix(read.csv("../fixtures/weights.csv", row.names=1, che
 # Testing
 
 test_that("Seminr estimates the loadings and path coefficients correctly", {
-  expect_equal(coefficients[,6], coefficients_control[,6])
+  expect_equal(coefficients[,6], coefficients_control[,6], tolerance = 0.00001)
 })
 
 test_that("Seminr estimates the construct scores correctly", {
-  expect_equal(construct_scores[,1:6], construct_scores_control[,1:6])
+  expect_equal(construct_scores[,1:6], construct_scores_control[,1:6], tolerance = 0.00001)
 })
 
 test_that("Seminr estimates the outer weights correctly", {
-  expect_equal(weight, weight_control)
+  expect_equal(weight, weight_control, tolerance = 0.00001)
 })
 
 context("SEMinR correctly estimates the model scaled product indicator\n")
@@ -109,14 +109,14 @@ weight_control <- as.matrix(read.csv("../fixtures/weights2.csv", row.names=1, ch
 # Testing
 
 test_that("Seminr estimates the loadings and path coefficients correctly", {
-  expect_equal(coefficients[,6], coefficients_control[,6])
+  expect_equal(coefficients[,6], coefficients_control[,6], tolerance = 0.00001)
 })
 
 test_that("Seminr estimates the construct scores correctly", {
-  expect_equal(construct_scores[,1:6], construct_scores_control[,1:6])
+  expect_equal(construct_scores[,1:6], construct_scores_control[,1:6], tolerance = 0.00001)
 })
 
 test_that("Seminr estimates the outer weights correctly", {
-  expect_equal(weight, weight_control)
+  expect_equal(weight, weight_control, tolerance = 0.00001)
 })
 

--- a/tests/testthat/test-summary.R
+++ b/tests/testthat/test-summary.R
@@ -43,11 +43,11 @@ reliability_control <- as.matrix(read.csv("../fixtures/reliability.csv", row.nam
 #})
 
 test_that("Seminr estimates the cross-loadings correctly", {
-  expect_equal(cross_loadings, cross_loadings_control)
+  expect_equal(cross_loadings, cross_loadings_control, tolerance = 0.00001)
 })
 
 test_that("Seminr estimates the reliability correctly", {
-  expect_equal(reliability, reliability_control)
+  expect_equal(reliability, reliability_control, tolerance = 0.00001)
 })
 
 context("SEMinR correctly returns the summary object for class boot_seminr_model\n")
@@ -87,11 +87,11 @@ p_values_control <- as.matrix(read.csv("../fixtures/pvalues.csv", row.names = 1)
 # Testing
 
 test_that("Seminr estimates the t-values correctly", {
-  expect_equal(t_values, t_values_control)
+  expect_equal(t_values, t_values_control, tolerance = 0.00001)
 })
 
 test_that("Seminr estimates the p-values correctly", {
-  expect_equal(p_values, p_values_control)
+  expect_equal(p_values, p_values_control, tolerance = 0.00001)
 })
 
 context("SEMinR:::evaluate_measurement_model() correctly evaluates FACTORS for class seminr_model\n")
@@ -133,15 +133,15 @@ factor_discriminant_validity_control <- as.matrix(read.csv("../fixtures/factor_d
 # Testing
 
 test_that("Seminr evaluates the factor reliability correctly", {
-  expect_equal(factor_reliability,factor_reliability_control)
+  expect_equal(factor_reliability,factor_reliability_control, tolerance = 0.00001)
 })
 
 test_that("Seminr evaluates the factor indicator reliability correctly", {
-  expect_equal(factor_indicator_reliability,factor_indicator_reliability_control)
+  expect_equal(factor_indicator_reliability,factor_indicator_reliability_control, tolerance = 0.00001)
 })
 
 test_that("Seminr evaluates the factor reliability correctly", {
-  expect_equal(factor_discriminant_validity,factor_discriminant_validity_control)
+  expect_equal(factor_discriminant_validity,factor_discriminant_validity_control, tolerance = 0.00001)
 })
 
 context("SEMinR:::evaluate_measurement_model() correctly evaluates COMPOSITES for class seminr_model\n")
@@ -160,11 +160,11 @@ composite_collinearity_control <- read.csv("../fixtures/composite_collinearity.c
 # Testing
 
 test_that("Seminr evaluates the composite indicator reliability correctly", {
-  expect_equal(composite_indicator_reliability,composite_indicator_reliability_control)
+  expect_equal(composite_indicator_reliability,composite_indicator_reliability_control, tolerance = 0.00001)
 })
 
 test_that("Seminr evaluates the composite collinearity correctly", {
-  expect_equal(unname(composite_collinearity[1:5]),composite_collinearity_control[1:5,1])
+  expect_equal(unname(composite_collinearity[1:5]),composite_collinearity_control[1:5,1], tolerance = 0.00001)
 })
 
 context("SEMinR:::boot_evaluate_measurement_model() correctly evaluates FACTORS for class boot_seminr_model\n")
@@ -183,11 +183,11 @@ factor_discriminant_validity_p_values_control <- as.matrix(read.csv("../fixtures
 # Testing
 
 test_that("Seminr evaluates the factor discriminant validity t_values control correctly", {
-  expect_equal(factor_discriminant_validity_t_values, factor_discriminant_validity_t_values_control)
+  expect_equal(factor_discriminant_validity_t_values, factor_discriminant_validity_t_values_control, tolerance = 0.00001)
 })
 
 test_that("Seminr evaluates the factor discriminant validity p_values correctly", {
-  expect_equal(factor_discriminant_validity_p_values, factor_discriminant_validity_p_values_control)
+  expect_equal(factor_discriminant_validity_p_values, factor_discriminant_validity_p_values_control, tolerance = 0.00001)
 })
 
 context("SEMinR:::boot_evaluate_measurement_model() correctly evaluates COMPOSITES for class boot_seminr_model\n")
@@ -206,9 +206,9 @@ composite_indicator_weights_p_values_control <- as.matrix(read.csv("../fixtures/
 # Testing
 
 test_that("Seminr evaluates the composite indicator t values correctly", {
-  expect_equal(composite_indicator_weights_t_values, composite_indicator_weights_t_values_control)
+  expect_equal(composite_indicator_weights_t_values, composite_indicator_weights_t_values_control, tolerance = 0.00001)
 })
 
 test_that("Seminr evaluates the composite collinearity correctly", {
-  expect_equal(composite_indicator_weights_p_values, composite_indicator_weights_p_values_control)
+  expect_equal(composite_indicator_weights_p_values, composite_indicator_weights_p_values_control, tolerance = 0.00001)
 })

--- a/tests/testthat/test_validity.R
+++ b/tests/testthat/test_validity.R
@@ -52,13 +52,13 @@ correct_vif_antecedents2 <- read.csv("../fixtures/vifs/flat_vif_antecedents2.csv
 
 ## Tests ----
 test_that("Seminr computes the item VIFs correctly", {
-  expect_equal(flat_vif_items1, correct_item_vifs1)
+  expect_equal(flat_vif_items1, correct_item_vifs1, tolerance = 0.00001)
 })
 
 test_that("Seminr computes the antecedent VIFs correctly for single endogenous variable", {
-  expect_equal(flat_vif_antecedents1, correct_vif_antecedents1)
+  expect_equal(flat_vif_antecedents1, correct_vif_antecedents1, tolerance = 0.00001)
 })
 
 test_that("Seminr computes the antecedent VIFs correctly for multiple endogenous variables", {
-  expect_equal(flat_vif_antecedents2, correct_vif_antecedents2)
+  expect_equal(flat_vif_antecedents2, correct_vif_antecedents2, tolerance = 0.00001)
 })


### PR DESCRIPTION
Modified all expect_equal() tests to have a tolerance of 0.00001 for floating point operations on 32bit platforms. R CMD CHECK passes all tests pass.