### PR TITLE
Fixed bootstrap bug to resolve #154

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,9 +2,7 @@ Package: seminr
 Type: Package
 Title: Domain-Specific Language for Building and Estimating Structural Equation Models
 Version: 1.1.0
-
 Date: 2020-07-23
-
 Authors@R: c(person("Soumya", "Ray", email = "soumya.ray@gmail.com", role = c("aut", "ths")),
              person("Nicholas Patrick", "Danks", email = "nicholasdanks@hotmail.com", role = c("aut","cre")),
              person("Juan Manuel Velasquez", "Estrada", role = "aut"),
@@ -14,7 +12,6 @@ Description: A powerful, easy to syntax for specifying and estimating complex
     Structural Equation Models. Models can be estimated using Partial 
     Least Squares Path Modeling or Covariance-Based Structural Equation 
     Modeling or covariance based Confirmatory Factor Analysis. 
-
 Imports:
     parallel, lavaan, MASS
 License: GPL-3

--- a/R/estimate_bootstrap.R
+++ b/R/estimate_bootstrap.R
@@ -104,11 +104,21 @@ bootstrap_model <- function(seminr_model, nboot = 500, cores = NULL, seed = NULL
         bootstrapMatrix <- cbind(bootstrapMatrix, matrix(apply(bootmatrix,1,stats::sd), nrow = rows, ncol = cols))
 
         # Create paths matrix
-        paths_descriptives <- bootstrapMatrix[1:(cols-1), c(1:(3*cols))]
+        paths_descriptives <- matrix(bootstrapMatrix[1:(cols-1), c(1:(3*cols))], nrow=(cols-1), ncol=(3*cols))
+        dimnames(paths_descriptives) <- list(
+          rownames(bootstrapMatrix)[1:(cols-1)],
+          colnames(bootstrapMatrix)[1:(3*cols)]
+        )
 
         # Clean the empty paths
-        paths_descriptives <- paths_descriptives[, colSums(paths_descriptives != 0, na.rm = TRUE) > 0]
-        paths_descriptives <- paths_descriptives[rowSums(paths_descriptives != 0, na.rm = TRUE) > 0, ]
+        filled_cols <- apply(paths_descriptives != 0, 2, any, na.rm=TRUE)
+        filled_rows <- apply(paths_descriptives != 0, 1, any, na.rm=TRUE)
+        paths_dimnames <- dimnames(paths_descriptives)
+        paths_descriptives <- matrix(paths_descriptives[filled_rows, filled_cols], nrow=sum(filled_rows), ncol=sum(filled_cols))
+        dimnames(paths_descriptives) <- list(
+          paths_dimnames[[1]][filled_rows],
+          paths_dimnames[[2]][filled_cols]
+        )
 
         # Get the number of DVs
         if (length(unique(structural_model[,"target"])) == 1) {

--- a/R/estimate_bootstrap.R
+++ b/R/estimate_bootstrap.R
@@ -87,7 +87,7 @@ bootstrap_model <- function(seminr_model, nboot = 500, cores = NULL, seed = NULL
 
         # Function to get PLS estimate results
         getEstimateResults <- function(i, d = d) {
-          set.seed(seed+i)
+          set.seed(seed + i)
           boot_model <- seminr::estimate_pls(data = d[getRandomIndex(d),],
                                measurement_model,
                                structural_model,
@@ -128,38 +128,38 @@ bootstrap_model <- function(seminr_model, nboot = 500, cores = NULL, seed = NULL
         }
 
         # Construct the vector of column names
-        colnames<-c()
+        col_names <- c()
         # Clean the column names
         for (parameter in c("PLS Est.", "Boot Mean", "Boot SD")) {
-          for(i in 1:length(dependant)) {
-            colnames <- c(colnames, paste(dependant[i], parameter, sep = " "))
+          for (i in 1:length(dependant)) {
+            col_names <- c(col_names, paste(dependant[i], parameter, sep = " "))
           }
         }
 
         # Assign column names
-        colnames(paths_descriptives) <- colnames
+        colnames(paths_descriptives) <- col_names
 
         # collect loadings matrix
         loadings_descriptives <- bootstrapMatrix[(cols+1):((cols)+nrow(seminr_model$outer_loadings)), c(1:(3*cols))]
 
 
         # Construct the vector of column names 2
-        colnames2<-c()
+        col_names2 <- c()
         # Clean the column names
         for (parameter in c("PLS Est.", "Boot Mean", "Boot SD")) {
           for(i in seminr_model$constructs) {
-            colnames2 <- c(colnames2, paste(i, parameter, sep = " "))
+            col_names2 <- c(col_names2, paste(i, parameter, sep = " "))
           }
         }
 
         # Assign column names to loadings
-        colnames(loadings_descriptives) <- colnames2
+        colnames(loadings_descriptives) <- col_names2
 
         # collect weights matrix
         weights_descriptives <- bootstrapMatrix[((cols+1)+nrow(seminr_model$outer_loadings)):((cols)+(2*nrow(seminr_model$outer_loadings))), c(1:(3*cols))]
 
         # Assign column names to weights
-        colnames(weights_descriptives) <- colnames2
+        colnames(weights_descriptives) <- col_names2
 
         # Collect HTMT matrix
         HTMT_descriptives <- bootstrapMatrix[((cols+1)+(2*nrow(seminr_model$outer_loadings))):((cols+cols)+(2*nrow(seminr_model$outer_loadings))), c(1:(3*cols))]
@@ -169,7 +169,7 @@ bootstrap_model <- function(seminr_model, nboot = 500, cores = NULL, seed = NULL
         #boot_HTMT <- boot_HTMT[rowSums(boot_HTMT != 0, na.rm = TRUE) > 0,]
 
         # Get boot_HTMT column names
-        colnames(HTMT_descriptives) <- colnames2
+        colnames(HTMT_descriptives) <- col_names2
 
         # Create an array of results in bootmatrix
         bootarray <- array(bootmatrix, dim = c(nrow(bootstrapMatrix), length(seminr_model$constructs),nboot), dimnames = list(c(rownames(bootstrapMatrix)), c(seminr_model$constructs), c(1:nboot)))
@@ -198,19 +198,19 @@ bootstrap_model <- function(seminr_model, nboot = 500, cores = NULL, seed = NULL
       cat("SEMinR Model successfully bootstrapped")
       return(seminr_model)
     },
-    error=function(cond) {
+    error = function(cond) {
       message("Bootstrapping encountered this ERROR: ")
       message(cond)
       parallel::stopCluster(cl)
       return(NULL)
     },
-    warning=function(cond) {
+    warning = function(cond) {
       message("Bootstrapping encountered this WARNING:")
       message(cond)
       parallel::stopCluster(cl)
       return(NULL)
     },
-    finally={
+    finally = {
       #
     }
   )

--- a/R/estimate_bootstrap.R
+++ b/R/estimate_bootstrap.R
@@ -103,22 +103,17 @@ bootstrap_model <- function(seminr_model, nboot = 500, cores = NULL, seed = NULL
         bootstrapMatrix <- cbind(bootstrapMatrix, matrix(apply(bootmatrix,1,mean), nrow = rows, ncol = cols))
         bootstrapMatrix <- cbind(bootstrapMatrix, matrix(apply(bootmatrix,1,stats::sd), nrow = rows, ncol = cols))
 
-        # Create paths matrix
+        # Subset paths matrix (take care to not be stranded with a single column/row vector)
         paths_descriptives <- matrix(bootstrapMatrix[1:(cols-1), c(1:(3*cols))], nrow=(cols-1), ncol=(3*cols))
         dimnames(paths_descriptives) <- list(
           rownames(bootstrapMatrix)[1:(cols-1)],
           colnames(bootstrapMatrix)[1:(3*cols)]
         )
 
-        # Clean the empty paths
+        # Clean the empty paths (take care to not be stranded with a single column/row vector)
         filled_cols <- apply(paths_descriptives != 0, 2, any, na.rm=TRUE)
         filled_rows <- apply(paths_descriptives != 0, 1, any, na.rm=TRUE)
-        paths_dimnames <- dimnames(paths_descriptives)
-        paths_descriptives <- matrix(paths_descriptives[filled_rows, filled_cols], nrow=sum(filled_rows), ncol=sum(filled_cols))
-        dimnames(paths_descriptives) <- list(
-          paths_dimnames[[1]][filled_rows],
-          paths_dimnames[[2]][filled_cols]
-        )
+        paths_descriptives <- subset(paths_descriptives, filled_rows, filled_cols)
 
         # Get the number of DVs
         if (length(unique(structural_model[,"target"])) == 1) {

--- a/tests/testthat/test-bootstrap.R
+++ b/tests/testthat/test-bootstrap.R
@@ -1,9 +1,28 @@
-context("SEMinR correctly bootstraps the simple model\n")
+context("SEMinR correctly bootstraps simple models\n")
+
+# Test cases
+## One antecedent model cases
+set.seed(123)
+
+inn_mm <- constructs(
+  composite("INN_P", multi_items("IMAG", 1:4)),
+  composite("INN_M", multi_items("PERQ", 1:4)),
+  composite("THIRD", multi_items("CUEX", 1:3))
+)
+
+inn_sm <- relationships(paths(from = "INN_P", to = "INN_M"))
+pls <- estimate_pls(data = mobi, inn_mm, inn_sm)
+expect_error(bootstrap_model(seminr_model = pls, nboot = 5), NA)
+
+inn_sm <- relationships(paths(from = "INN_P", to = c("INN_M", "THIRD")))
+pls <- estimate_pls(data = mobi, inn_mm, inn_sm)
+expect_error(bootstrap_model(seminr_model = pls, nboot = 5), NA)
+
 
 # Test cases
 ## Simple case
 set.seed(123)
-# seminr syntax for creating measurement model
+
 mobi_mm <- constructs(
   composite("Image",        multi_items("IMAG", 1:5), weights = mode_A),
   composite("Expectation",  multi_items("CUEX", 1:3), weights = mode_A),
@@ -11,8 +30,6 @@ mobi_mm <- constructs(
   composite("Satisfaction", multi_items("CUSA", 1:3), weights = mode_A)
 )
 
-# structural model: note that name of the interactions construct should be
-#  the names of its two main constructs joined by a '*' in between.
 mobi_sm <- relationships(
   paths(to = "Satisfaction",
         from = c("Image", "Expectation", "Value"))
@@ -46,7 +63,6 @@ context("SEMinR correctly bootstraps the interaction model\n")
 # Test cases
 ## Interaction case
 
-# seminr syntax for creating measurement model
 mobi_mm <- constructs(
   composite("Image",        multi_items("IMAG", 1:5), weights = correlation_weights),
   composite("Expectation",  multi_items("CUEX", 1:3), weights = correlation_weights),
@@ -56,8 +72,6 @@ mobi_mm <- constructs(
   interaction_term(iv = "Image", moderator = "Value", method = orthogonal, weights = mode_A)
 )
 
-# structural model: note that name of the interactions construct should be
-#  the names of its two main constructs joined by a '*' in between.
 mobi_sm <- relationships(
   paths(to = "Satisfaction",
         from = c("Image", "Expectation", "Value",
@@ -91,7 +105,6 @@ context("SEMinR correctly bootstraps the model weights - composite measurement m
 # Test cases
 ## Regular model
 
-# seminr syntax for creating measurement model
 mobi_mm <- constructs(
   composite("Image",        multi_items("IMAG", 1:5), weights = correlation_weights),
   composite("Expectation",  multi_items("CUEX", 1:3), weights = correlation_weights),
@@ -99,8 +112,6 @@ mobi_mm <- constructs(
   composite("Satisfaction", multi_items("CUSA", 1:3), weights = correlation_weights)
 )
 
-# structural model: note that name of the interactions construct should be
-#  the names of its two main constructs joined by a '*' in between.
 mobi_sm <- relationships(
   paths(to = "Satisfaction",
         from = c("Image", "Expectation", "Value"))
@@ -133,7 +144,6 @@ context("SEMinR correctly bootstraps the model loadings - factor measurement mod
 # Test cases
 ## Regular model
 
-# seminr syntax for creating measurement model
 mobi_mm <- constructs(
   reflective("Image",        multi_items("IMAG", 1:5)),
   reflective("Expectation",  multi_items("CUEX", 1:3)),
@@ -141,8 +151,6 @@ mobi_mm <- constructs(
   reflective("Satisfaction", multi_items("CUSA", 1:3))
 )
 
-# structural model: note that name of the interactions construct should be
-#  the names of its two main constructs joined by a '*' in between.
 mobi_sm <- relationships(
   paths(to = "Satisfaction",
         from = c("Image", "Expectation", "Value"))
@@ -199,7 +207,6 @@ context("SEMinR correctly reports the confidence interval bootstrapped paths\n")
 # Test cases
 ## Simple case
 set.seed(123)
-# seminr syntax for creating measurement model
 mobi_mm <- constructs(
   composite("Image",        multi_items("IMAG", 1:5), weights = mode_A),
   composite("Expectation",  multi_items("CUEX", 1:3), weights = mode_A),
@@ -207,8 +214,6 @@ mobi_mm <- constructs(
   composite("Satisfaction", multi_items("CUSA", 1:3), weights = mode_A)
 )
 
-# structural model: note that name of the interactions construct should be
-#  the names of its two main constructs joined by a '*' in between.
 mobi_sm <- relationships(
   paths(to = "Satisfaction",
         from = c("Image", "Expectation", "Value")),


### PR DESCRIPTION
Bootstrapping a model with only one antecedent created degenerate paths matrix (subseting caused it to become a vector). Fixed it by ensuring a matrix always results from subsets of path matrix (in two places).

Also cleaned up some naming glitches from initial bootstrapping implementation.