### PR TITLE
Plot reliablity metrics relative differences

### DIFF
--- a/R/plot_results.R
+++ b/R/plot_results.R
@@ -15,6 +15,9 @@ plot.reliability_table <- function(x, ...) {
   plot(metrics[,1:2], xlim=c(1, nrow(metrics[,-1])), ylim=c(min(metrics[,-1]), max(metrics[,-1])),
        frame.plot = FALSE, xaxt='n', ylab='', xlab = '', pch='')
 
+  # Grid
+  grid(nx = NULL, ny = NULL, col = "lightgray", lty = "dotted")
+
   # rhoA line and shape
   graphics::segments(metrics[,1]-0.2, metrics[, "rhoA"], metrics[,1]+0.2, metrics[, "rhoA"])
   graphics::points(metrics[,1], metrics[, "rhoA"], pch=15)

--- a/R/plot_results.R
+++ b/R/plot_results.R
@@ -10,16 +10,30 @@ plot_scores <- function(seminr_model, constructs=NULL) {
 #' @export
 plot.reliability_table <- function(x, ...) {
   stopifnot(inherits(x, "reliability_table"))
-  graphics::barplot(t(x[,c(1,2,4)]),
-                    # col=colors()[c(23,89,12)] ,
-                    col = ifelse(t(x[,c(1,2,4)]) > 0.7, c("palegreen4"), "orangered3"),
-                    border="white",
-                    font.axis=1,
-                    beside=T,
-                    xlab="Reliability",
-                    font.lab=2,
-                    names.arg =rep(rownames(t(x[,c(1,2,4)])),ncol(t(x[,c(1,2,4)]))),
-                    las = 2)
+
+  metrics <- cbind(1:nrow(x), x)
+  plot(metrics[,1:2], xlim=c(1, nrow(metrics[,-1])), ylim=c(min(metrics[,-1]), max(metrics[,-1])),
+       frame.plot = FALSE, xaxt='n', ylab='', xlab = '', pch='')
+
+  # rhoA line and shape
+  graphics::segments(metrics[,1]-0.2, metrics[, "rhoA"], metrics[,1]+0.2, metrics[, "rhoA"])
+  graphics::points(metrics[,1], metrics[, "rhoA"], pch=15)
+
+  # alpha line and shape
+  graphics::segments(metrics[,1]-0.1, metrics[, "rhoA"], metrics[,1]-0.1, metrics[, "alpha"])
+  graphics::points(metrics[,1]-0.1, metrics[, "alpha"], pch=19)
+
+  # rhoC line and shape
+  graphics::segments(metrics[,1]+0.1, metrics[, "rhoA"], metrics[,1]+0.1, metrics[, "rhoC"])
+  graphics::points(metrics[,1]+0.1, metrics[, "rhoC"], pch=17)
+
+  # threshhold line
   graphics::abline(h = 0.708, lty = 2, col = "blue")
+
+  # rotated axis labels: https://www.tenderisthebyte.com/blog/2019/04/25/rotating-axis-labels-in-r/
+  axis(side = 1, labels = FALSE)
+  text(x = 1:nrow(metrics), y = par("usr")[3] - 0.03,
+       labels = rownames(metrics), xpd = NA, srt = 35, adj = 0.965)
+
   invisible(x)
 }


### PR DESCRIPTION
I've updated plotting of reliability metrics to use a point plot with relative differences.

One issue I faced was that the x-axis (construct) labels would not all display if the plot was too narrow. A workaround is to rotate the labels by 45 degrees.  Now, the labels should appear correctly no matter the width of the plot.

@NicholasDanks please try it on a few different datasets -- I'm not entirely sure if the x-axis labels will work with different y-axis values.