### PR TITLE
Fix CBSEM HOC summary, fixes #271, fixes #247, fixes #214

### DIFF
--- a/R/estimate_cbsem.R
+++ b/R/estimate_cbsem.R
@@ -153,8 +153,9 @@ estimate_cbsem <- function(data, measurement_model=NULL, structural_model=NULL, 
   # Inspect results
   constructs <- all_construct_names(measurement_model)
   lavaan_std <- lavaan::lavInspect(lavaan_output, what="std")
-  loadings <- lavaan_std$lambda
-  class(loadings) <- "matrix"
+  # loadings <- lavaan_std$lambda
+  # class(loadings) <- "matrix"
+  loadings <- combine_first_order_second_order_loadings_cbsem(mmMatrix, rawdata, lavaan_std)
   tenB <- estimate_lavaan_ten_berge(lavaan_output)
 
   # Path Coefficients Table

--- a/R/estimate_cbsem.R
+++ b/R/estimate_cbsem.R
@@ -106,6 +106,7 @@ estimate_cbsem <- function(data, measurement_model=NULL, structural_model=NULL, 
   message("Generating the seminr model for CBSEM")
 
   # TODO: consider higher order models (see estimate_pls() function for template)
+  rawdata <- data
 
   if (is.null(lavaan_model)) {
     # Extract model specifications
@@ -168,6 +169,7 @@ estimate_cbsem <- function(data, measurement_model=NULL, structural_model=NULL, 
   # Gather model information
   seminr_model <- list(
     data = data,
+    rawdata = rawdata,
     measurement_model = measurement_model,
     factor_loadings = loadings,
     associations = item_associations,

--- a/R/estimate_cbsem.R
+++ b/R/estimate_cbsem.R
@@ -153,7 +153,7 @@ estimate_cbsem <- function(data, measurement_model=NULL, structural_model=NULL, 
   # Inspect results
   constructs <- all_construct_names(measurement_model)
   lavaan_std <- lavaan::lavInspect(lavaan_output, what="std")
-  HOCs <- HOCs_in_sm(measurement_model, structural_model)
+  HOCs <- HOCs_in_model(measurement_model, structural_model)
   if (length(HOCs) > 0) {
     loadings <- combine_first_order_second_order_loadings_cbsem(mmMatrix, rawdata, lavaan_std)
   } else {
@@ -274,13 +274,13 @@ estimate_cfa <- function(data, measurement_model=NULL, item_associations=NULL,
 
   constructs <- all_construct_names(measurement_model)
   lavaan_std <- lavaan::lavInspect(lavaan_output, what="std")
-  # HOCs <- HOCs_in_sm(measurement_model, structural_model)
-  # if (length(HOCs) > 0) {
-  #   loadings <- combine_first_order_second_order_loadings_cbsem(mmMatrix, rawdata, lavaan_std)
-  # } else {
+  HOCs <- HOCs_in_model(measurement_model)
+  if (length(HOCs) > 0) {
+    loadings <- combine_first_order_second_order_loadings_cbsem(mmMatrix, rawdata, lavaan_std)
+  } else {
     loadings <- lavaan_std$lambda
     class(loadings) <- "matrix"
-  # }
+  }
 
   tenB <- estimate_lavaan_ten_berge(lavaan_output)
 

--- a/R/estimate_cbsem.R
+++ b/R/estimate_cbsem.R
@@ -153,9 +153,14 @@ estimate_cbsem <- function(data, measurement_model=NULL, structural_model=NULL, 
   # Inspect results
   constructs <- all_construct_names(measurement_model)
   lavaan_std <- lavaan::lavInspect(lavaan_output, what="std")
-  # loadings <- lavaan_std$lambda
-  # class(loadings) <- "matrix"
-  loadings <- combine_first_order_second_order_loadings_cbsem(mmMatrix, rawdata, lavaan_std)
+  HOCs <- HOCs_in_sm(measurement_model, structural_model)
+  if (length(HOCs) > 0) {
+    loadings <- combine_first_order_second_order_loadings_cbsem(mmMatrix, rawdata, lavaan_std)
+  } else {
+    loadings <- lavaan_std$lambda
+    class(loadings) <- "matrix"
+  }
+
   tenB <- estimate_lavaan_ten_berge(lavaan_output)
 
   # Path Coefficients Table

--- a/R/estimate_cbsem.R
+++ b/R/estimate_cbsem.R
@@ -272,12 +272,24 @@ estimate_cfa <- function(data, measurement_model=NULL, item_associations=NULL,
     "run CFA in Lavaan"
   )
 
+  constructs <- all_construct_names(measurement_model)
+  lavaan_std <- lavaan::lavInspect(lavaan_output, what="std")
+  # HOCs <- HOCs_in_sm(measurement_model, structural_model)
+  # if (length(HOCs) > 0) {
+  #   loadings <- combine_first_order_second_order_loadings_cbsem(mmMatrix, rawdata, lavaan_std)
+  # } else {
+    loadings <- lavaan_std$lambda
+    class(loadings) <- "matrix"
+  # }
+
   tenB <- estimate_lavaan_ten_berge(lavaan_output)
 
   # Gather model information
   seminr_model <- list(
     data = data,
     measurement_model = measurement_model,
+    factor_loadings = loadings,
+    constructs = constructs,
     construct_scores = tenB$scores,
     item_weights = tenB$weights,
     lavaan_model = lavaan_model,

--- a/R/estimate_pls.R
+++ b/R/estimate_pls.R
@@ -118,7 +118,7 @@ estimate_pls <- function(data,
   structural_model <- specified_model$structural_model
 
   # Generate first order model if necessary
-  HOCs <- HOCs_in_sm(measurement_model, structural_model)
+  HOCs <- HOCs_in_model(measurement_model, structural_model)
 
   if ( length(HOCs)>0 ) {
     HOM <- prepare_higher_order_model(data = data,

--- a/R/feature_higher_order.R
+++ b/R/feature_higher_order.R
@@ -79,9 +79,9 @@ prepare_higher_order_model <- function(data, sm , mm, inners, HOCs, maxIt, stopC
 }
 
 # Function to check that the HOCs exist in the structural model under analysis
-HOCs_in_sm <- function(measurement_model, structural_model) {
-  # HOCs <- measurement_model[names(measurement_model) == "higher_order_composite"]
+HOCs_in_sm <- function(measurement_model, structural_model = NULL) {
   HOCs <- measurement_model[grepl("higher_order_", names(measurement_model))]
+
   if (length(HOCs) > 0) {
     output <- list()
     for (i in 1:length(HOCs)) {
@@ -92,6 +92,7 @@ HOCs_in_sm <- function(measurement_model, structural_model) {
   } else {
     output <- c()
   }
+
   return(output)
 }
 

--- a/R/feature_higher_order.R
+++ b/R/feature_higher_order.R
@@ -78,11 +78,13 @@ prepare_higher_order_model <- function(data, sm , mm, inners, HOCs, maxIt, stopC
               first_stage_model = new_model))
 }
 
-# Function to check that the HOCs exist in the structural model under analysis
+# Returns all Higher Order Constructs (HOCs) from provided model specifications
 HOCs_in_model <- function(measurement_model, structural_model = NULL) {
+  # Extract HOCs from measurement model
   HOCs <- measurement_model[grepl("higher_order_", names(measurement_model))]
   if (is.null(structural_model)) return(HOCs)
 
+  # Get subset of HOCs also present in structural model, if one is provided
   if (length(HOCs) > 0) {
     output <- list()
     for (i in 1:length(HOCs)) {

--- a/R/feature_higher_order.R
+++ b/R/feature_higher_order.R
@@ -79,8 +79,9 @@ prepare_higher_order_model <- function(data, sm , mm, inners, HOCs, maxIt, stopC
 }
 
 # Function to check that the HOCs exist in the structural model under analysis
-HOCs_in_sm <- function(measurement_model, structural_model = NULL) {
+HOCs_in_model <- function(measurement_model, structural_model = NULL) {
   HOCs <- measurement_model[grepl("higher_order_", names(measurement_model))]
+  if (is.null(structural_model)) return(HOCs)
 
   if (length(HOCs) > 0) {
     output <- list()

--- a/R/feature_higher_order.R
+++ b/R/feature_higher_order.R
@@ -80,7 +80,8 @@ prepare_higher_order_model <- function(data, sm , mm, inners, HOCs, maxIt, stopC
 
 # Function to check that the HOCs exist in the structural model under analysis
 HOCs_in_sm <- function(measurement_model, structural_model) {
-  HOCs <- measurement_model[names(measurement_model) == "higher_order_composite"]
+  # HOCs <- measurement_model[names(measurement_model) == "higher_order_composite"]
+  HOCs <- measurement_model[grepl("higher_order_", names(measurement_model))]
   if (length(HOCs) > 0) {
     output <- list()
     for (i in 1:length(HOCs)) {
@@ -154,7 +155,6 @@ combine_first_order_second_order_loadings_cbsem <- function(mmMatrix, rawdata, l
 
   HOC_measures <- lapply(setNames(HOC_names, HOC_names),
                          function(name) { HOCs[HOCs[, "construct"] == name, "measurement"] })
-
 
   loadings <- lavaan_std$lambda
   class(loadings) <- "matrix"

--- a/R/inspect_mmMatrix.R
+++ b/R/inspect_mmMatrix.R
@@ -160,7 +160,7 @@ mm2matrix <- function(measurement_model) {
     return(measurement_model)
   }
 
-  recognized_constructs <- c("composite", "reflective", "higher_order_composite")
+  recognized_constructs <- c("composite", "reflective", "higher_order_composite", "higher_order_reflective")
   construct_measurements <- measurement_model[names(measurement_model) %in% recognized_constructs]
   mmMatrix <- matrix(
     unlist(construct_measurements), ncol = 3, byrow = TRUE,

--- a/R/report_lavaan.R
+++ b/R/report_lavaan.R
@@ -20,8 +20,8 @@ summarize_cb_measurement <- function(object, alpha=0.05) {
   colnames(significance) <- c( "Std Estimate", "SE", "t-Value", paste(alpha_text, "% CI", sep = ""), paste((100-alpha_text), "% CI", sep = ""))
 
   # Get descriptives and correlations
-  # item_descriptives <- desc(object$data)
-  item_correlations <- stats::cor(object$data[, model$item_names])
+  available_item_names <- intersect(names(object$data), model$item_names)
+  item_correlations <- stats::cor(object$data[, available_item_names])
   construct_correlations <- lavaan::lavInspect(lavaan_output, what = "cor.lv")
 
   list(
@@ -37,10 +37,6 @@ summarize_cb_measurement <- function(object, alpha=0.05) {
     ),
     model = model,
     descriptives = list(
-      # TODO: report item descriptive stats
-      # statistics = list(
-      #   items = item_descriptives
-      # ),
       correlations = list(
         items = item_correlations,
         constructs = construct_correlations

--- a/R/specify_constructs.R
+++ b/R/specify_constructs.R
@@ -204,7 +204,9 @@ single_item <- function(item) {
 #'   )
 #' @export
 higher_reflective <- function(construct_name, dimensions) {
-  reflective(construct_name = construct_name, item_names = dimensions)
+  construct <- reflective(construct_name = construct_name, item_names = dimensions)
+  class(construct) <- c(class(construct)[1], c("construct", "higher_order_reflective"))
+  return(construct)
 }
 
 #' higher_composite

--- a/tests/testthat/test-cbsem-higher-order.R
+++ b/tests/testthat/test-cbsem-higher-order.R
@@ -1,7 +1,6 @@
 context("SEMinR correctly specifies higher-order factors for CBSEM\n")
 
-  # reflective("Value",        multi_items("PERV", 1:2)),
-# Test cases
+## Test Single HOF in a model
 mobi_mm <- constructs(
   reflective("Image",        multi_items("IMAG", 1:5)),
   reflective("Satisfaction", multi_items("CUSA", 1:3)),
@@ -24,6 +23,9 @@ test_that("Seminr estimates PI interaction paths correctly\n", {
 
 test_that("Seminr estimates higher order factor loadings\n", {
   expect_true(all(hof_cbsem$factor_loadings[c("Image", "Satisfaction"), "ImageSat"] > 0))
+})
+
+test_that("Seminr estimates zero loadings on non-HOF constructs\n", {
   first_order_measures <- which(rownames(hof_cbsem$factor_loadings) %in% c("Image", "Satisfaction"))
   expect_true(all(hof_cbsem$factor_loadings[-first_order_measures, "ImageSat"] == 0))
 })
@@ -32,20 +34,51 @@ test_that("Seminr summarizes higher-order factor reliabilities\n", {
   expect_true(all(hof_summary$quality$reliability["ImageSat",] > 0))
 })
 
-#
-# mobi_mm2 <- constructs(
-#   reflective("Image",        multi_items("IMAG", 1:5)),
-#   reflective("Satisfaction", multi_items("CUSA", 1:3)),
-#   higher_reflective("ImageSat", c("Image", "Satisfaction")),
-#   reflective("Expectation", multi_items("CUEX", 1:3)),
-#   reflective("Loyalty",     multi_items("CUSL", 1:3)),
-#   higher_reflective("ExpLoy", c("Expectation", "Loyalty"))
-# )
-#
-# mobi_sm2 <- relationships(
-#   paths(from = c("ImageSat"), to=c("ExpLoy"))
-# )
-#
-# hof_cbsem2 <- estimate_cbsem(data = mobi, measurement_model = mobi_mm2, structural_model = mobi_sm2)
-#
-# hof_summary <- summary(hof_cbsem)
+## Test multiple HOFs in a model
+mobi_mm2 <- constructs(
+  reflective("Image",          multi_items("IMAG", 1:5)),
+  reflective("Satisfaction",    multi_items("CUSA", 1:3)),
+  reflective("Expectation",     multi_items("CUEX", 1:3)),
+  reflective("Loyalty",         multi_items("CUSL", 1:3)),
+  reflective("Quality",        multi_items("PERQ", 1:7)),
+  reflective("Value",           multi_items("PERV", 1:2)),
+  reflective("Complaints",      single_item("CUSCO")),
+  higher_reflective("QualExpImg", c("Quality", "Expectation", "Image")),
+  higher_reflective("SatComp", c("Satisfaction", "Complaints"))
+)
+
+mobi_sm2 <- relationships(
+  paths(from = c("SatComp", "Value", "Loyalty"), to=c("QualExpImg"))
+)
+
+hof_cbsem2 <- estimate_cbsem(data = mobi, measurement_model = mobi_mm2, structural_model = mobi_sm2, check.gradient = FALSE)
+
+hof_summary2 <- summary(hof_cbsem2)
+
+# First HOF of model
+test_that("Seminr estimates higher order factor loadings with multiple HOFs (HOF 1)\n", {
+  expect_true(all(hof_cbsem2$factor_loadings[c("Quality", "Expectation", "Image"), "QualExpImg"] > 0))
+})
+
+test_that("Seminr estimates zero loadings on non-HOF constructs (HOF 1)\n", {
+  first_order_measures <- which(rownames(hof_cbsem2$factor_loadings) %in% c("Quality", "Expectation", "Image"))
+  expect_true(all(hof_cbsem2$factor_loadings[-first_order_measures, "QualExpImg"] == 0))
+})
+
+test_that("Seminr summarizes higher-order factor reliabilities (HOF 1)\n", {
+  expect_true(all(hof_summary2$quality$reliability["QualExpImg",] > 0))
+})
+
+# Second HOF of model
+test_that("Seminr estimates higher order factor loadings with multiple HOFs (HOF 2)\n", {
+  expect_true(all(hof_cbsem2$factor_loadings[c("Satisfaction", "Complaints"), "SatComp"] > 0))
+})
+
+test_that("Seminr estimates zero loadings on non-HOF constructs (HOF 1)\n", {
+  first_order_measures <- which(rownames(hof_cbsem2$factor_loadings) %in% c("Satisfaction", "Complaints"))
+  expect_true(all(hof_cbsem2$factor_loadings[-first_order_measures, "SatComp"] == 0))
+})
+
+test_that("Seminr summarizes higher-order factor reliabilities (HOF 1)\n", {
+  expect_true(all(hof_summary2$quality$reliability["SatComp",] > 0))
+})

--- a/tests/testthat/test-cbsem-higher-order.R
+++ b/tests/testthat/test-cbsem-higher-order.R
@@ -1,6 +1,6 @@
 context("SEMinR correctly specifies higher-order factors for CBSEM\n")
 
-## Test Single HOF in a model
+## Test Single HOC in a model
 mobi_mm <- constructs(
   reflective("Image",        multi_items("IMAG", 1:5)),
   reflective("Satisfaction", multi_items("CUSA", 1:3)),
@@ -13,9 +13,9 @@ mobi_sm <- relationships(
   paths(from = c("ImageSat", "Satisfaction", "Expectation"), to="Loyalty")
 )
 
+# hof_cba <- estimate_cfa(data = mobi, measurement_model = mobi_mm)
 hof_cbsem <- estimate_cbsem(data = mobi, measurement_model = mobi_mm, structural_model = mobi_sm)
-
-hof_summary <- summary(hof_cbsem)
+hof_cbsem_summary <- summary(hof_cbsem)
 
 test_that("Seminr estimates PI interaction paths correctly\n", {
   expect_match(hof_cbsem$lavaan_model, "ImageSat =~ Image \\+ Satisfaction")
@@ -25,16 +25,16 @@ test_that("Seminr estimates higher order factor loadings\n", {
   expect_true(all(hof_cbsem$factor_loadings[c("Image", "Satisfaction"), "ImageSat"] > 0))
 })
 
-test_that("Seminr estimates zero loadings on non-HOF constructs\n", {
+test_that("Seminr estimates zero loadings on non-HOC constructs\n", {
   first_order_measures <- which(rownames(hof_cbsem$factor_loadings) %in% c("Image", "Satisfaction"))
   expect_true(all(hof_cbsem$factor_loadings[-first_order_measures, "ImageSat"] == 0))
 })
 
 test_that("Seminr summarizes higher-order factor reliabilities\n", {
-  expect_true(all(hof_summary$quality$reliability["ImageSat",] > 0))
+  expect_true(all(hof_cbsem_summary$quality$reliability["ImageSat",] > 0))
 })
 
-## Test multiple HOFs in a model
+## Test multiple HOCs in a model
 mobi_mm2 <- constructs(
   reflective("Image",          multi_items("IMAG", 1:5)),
   reflective("Satisfaction",    multi_items("CUSA", 1:3)),
@@ -53,32 +53,34 @@ mobi_sm2 <- relationships(
 
 hof_cbsem2 <- estimate_cbsem(data = mobi, measurement_model = mobi_mm2, structural_model = mobi_sm2, check.gradient = FALSE)
 
-hof_summary2 <- summary(hof_cbsem2)
+hof_cbsem2_summary <- summary(hof_cbsem2)
 
-# First HOF of model
-test_that("Seminr estimates higher order factor loadings with multiple HOFs (HOF 1)\n", {
+# TODO: make identified 2nd order CFA and test loadings, reliabilities
+
+# First HOC of model
+test_that("Seminr estimates higher order factor loadings with multiple HOCs (HOC 1)\n", {
   expect_true(all(hof_cbsem2$factor_loadings[c("Quality", "Expectation", "Image"), "QualExpImg"] > 0))
 })
 
-test_that("Seminr estimates zero loadings on non-HOF constructs (HOF 1)\n", {
+test_that("Seminr estimates zero loadings on non-HOC constructs (HOC 1)\n", {
   first_order_measures <- which(rownames(hof_cbsem2$factor_loadings) %in% c("Quality", "Expectation", "Image"))
   expect_true(all(hof_cbsem2$factor_loadings[-first_order_measures, "QualExpImg"] == 0))
 })
 
-test_that("Seminr summarizes higher-order factor reliabilities (HOF 1)\n", {
-  expect_true(all(hof_summary2$quality$reliability["QualExpImg",] > 0))
+test_that("Seminr summarizes higher-order factor reliabilities (HOC 1)\n", {
+  expect_true(all(hof_cbsem2_summary$quality$reliability["QualExpImg",] > 0))
 })
 
-# Second HOF of model
-test_that("Seminr estimates higher order factor loadings with multiple HOFs (HOF 2)\n", {
+# Second HOC of model
+test_that("Seminr estimates higher order factor loadings with multiple HOCs (HOC 2)\n", {
   expect_true(all(hof_cbsem2$factor_loadings[c("Satisfaction", "Complaints"), "SatComp"] > 0))
 })
 
-test_that("Seminr estimates zero loadings on non-HOF constructs (HOF 1)\n", {
+test_that("Seminr estimates zero loadings on non-HOC constructs (HOC 1)\n", {
   first_order_measures <- which(rownames(hof_cbsem2$factor_loadings) %in% c("Satisfaction", "Complaints"))
   expect_true(all(hof_cbsem2$factor_loadings[-first_order_measures, "SatComp"] == 0))
 })
 
-test_that("Seminr summarizes higher-order factor reliabilities (HOF 1)\n", {
-  expect_true(all(hof_summary2$quality$reliability["SatComp",] > 0))
+test_that("Seminr summarizes higher-order factor reliabilities (HOC 1)\n", {
+  expect_true(all(hof_cbsem2_summary$quality$reliability["SatComp",] > 0))
 })

--- a/tests/testthat/test-cbsem-higher-order.R
+++ b/tests/testthat/test-cbsem-higher-order.R
@@ -16,6 +16,36 @@ mobi_sm <- relationships(
 
 hof_cbsem <- estimate_cbsem(data = mobi, measurement_model = mobi_mm, structural_model = mobi_sm)
 
+hof_summary <- summary(hof_cbsem)
+
 test_that("Seminr estimates PI interaction paths correctly\n", {
   expect_match(hof_cbsem$lavaan_model, "ImageSat =~ Image \\+ Satisfaction")
 })
+
+test_that("Seminr estimates higher order factor loadings\n", {
+  expect_true(all(hof_cbsem$factor_loadings[c("Image", "Satisfaction"), "ImageSat"] > 0))
+  first_order_measures <- which(rownames(hof_cbsem$factor_loadings) %in% c("Image", "Satisfaction"))
+  expect_true(all(hof_cbsem$factor_loadings[-first_order_measures, "ImageSat"] == 0))
+})
+
+test_that("Seminr summarizes higher-order factor reliabilities\n", {
+  expect_true(all(hof_summary$quality$reliability["ImageSat",] > 0))
+})
+
+#
+# mobi_mm2 <- constructs(
+#   reflective("Image",        multi_items("IMAG", 1:5)),
+#   reflective("Satisfaction", multi_items("CUSA", 1:3)),
+#   higher_reflective("ImageSat", c("Image", "Satisfaction")),
+#   reflective("Expectation", multi_items("CUEX", 1:3)),
+#   reflective("Loyalty",     multi_items("CUSL", 1:3)),
+#   higher_reflective("ExpLoy", c("Expectation", "Loyalty"))
+# )
+#
+# mobi_sm2 <- relationships(
+#   paths(from = c("ImageSat"), to=c("ExpLoy"))
+# )
+#
+# hof_cbsem2 <- estimate_cbsem(data = mobi, measurement_model = mobi_mm2, structural_model = mobi_sm2)
+#
+# hof_summary <- summary(hof_cbsem)

--- a/tests/testthat/test-cbsem.R
+++ b/tests/testthat/test-cbsem.R
@@ -36,9 +36,14 @@ sm <- relationships(
   paths(from = c("Value", "Satisfaction"),         to = "Complaints")
 )
 
+cbcfa <- estimate_cfa(mobi, mm_r)
+
 test_that("Measurement model CFA is estimated", {
-  cbcfa <- estimate_cfa(mobi, mm_r)
   expect_true(!is.null(cbcfa))
+})
+
+test_that("CFA reports right number of non-zero loadings", {
+  expect_equal(sum(cbcfa$factor_loadings != 0), 14)
 })
 
 test_that("CBSEM with measurement structure is estimated", {

--- a/tests/testthat/test-summary-cbsem.R
+++ b/tests/testthat/test-summary-cbsem.R
@@ -105,3 +105,8 @@ test_that("Summary of CFA has proper structure", {
   expect_equal(seminr:::traverse_names(cfa_summary),
                seminr:::traverse_names(cfa_summary_tree))
 })
+
+test_that("Summary of CFA has reliability values", {
+  expect_equal(nrow(cfa_summary$quality$reliability), 3)
+  expect_true(all(cfa_summary$quality$reliability > 0))
+})


### PR DESCRIPTION
Loadings of HOCs not reported by `estimate_cbsem()` and thus reliabilities of HOCs break for `rhoC_AVE.cbsem_model()`

Progress:
- [x] `estimate_cbsem()`: Extract and return HOC loadings from Lavaan's beta matrix
- [x] Ensure that reliabilities for HOCs work
- [x] Write a test to ensure HOC loadings and reliabilties are reported for CBSEM with one HOC
- [x] Ensure that loadings and reliabilities work for multiple HOCs present in model
- [x] Write a test to ensure HOC loadings and reliabilties are reported for CBSEM with multiple HOCs
- [x] Add constructs, loadings to CFA object
- [x] Add reliabilities to CFA summary
- [ ] ~~Add fix for CFA as well~~: handle later when association/variance constraints allow identifiable 2nd order CFA
- [ ] ~~Write a test to ensure HOC loadings and reliabilties are reported for CFA with >=1 HOCs~~
- [x] Refactor:
  - [x] HOF -> HOC, higher order composites -> higher order constructs