### PR TITLE
Fix plot(hoc_model) 

### DIFF
--- a/R/plot_dot.R
+++ b/R/plot_dot.R
@@ -1206,7 +1206,13 @@ dot_component_mm <- function(model, theme) {
                                 "// ---------------------\n"))
 
   # we use mmMatrix because model$constructs does not contain HOCs
-  mm_count <- length(unique(model$mmMatrix[,1 ]))
+  if (is.null(model$first_stage_model)) {
+    mm_count <- length(unique(model$mmMatrix[,1 ]))
+  } else {
+    mm_count <- length(intersect(unique(c(model$smMatrix, model$first_stage_model$smMatrix)),unique(model$mmMatrix[,1 ])))
+  }
+
+
   for (i in 1:mm_count) {
     sub_component <- dot_subcomponent_mm(i, model, theme)
     sub_components_mm <- c(sub_components_mm, sub_component)
@@ -1277,9 +1283,17 @@ extract_mm_coding <- function(model) {
   construct_types <- c()
 
   # iterate over all constructs in the mmMatrix
-  for (construct in unique(model$mmMatrix[,1 ])) {
-    construct_names <- c(construct_names, construct)
-    construct_types <- c(construct_types, get_construct_type(model, construct))
+  if (is.null(model$first_stage_model)) {
+    for (construct in unique(model$mmMatrix[,1 ])) {
+      construct_names <- c(construct_names, construct)
+      construct_types <- c(construct_types, get_construct_type(model, construct))
+    }
+  } else {
+    constructs_in_hoc_model <- intersect(unique(c(model$smMatrix, model$first_stage_model$smMatrix)),unique(model$mmMatrix[,1 ]))
+    for (construct in constructs_in_hoc_model) {
+      construct_names <- c(construct_names, construct)
+      construct_types <- c(construct_types, get_construct_type(model, construct))
+    }
   }
 
   # create output matrix

--- a/tests/testthat/test-plot-hoc.R
+++ b/tests/testthat/test-plot-hoc.R
@@ -88,3 +88,35 @@ test_that("two higher order composits are plotted", {
 
   }
 })
+
+test_that("higher order composits are plotted despite differing mm and sm constructs", {
+  set.seed(123)
+  mobi <- mobi
+  mobi_mm <- constructs(
+    composite("Image",        multi_items("IMAG", 1:5)),
+    composite("Expectation",  multi_items("CUEX", 1:3)),
+    composite("Quality",      multi_items("PERQ", 1:5)),
+    composite("Loyalty",      multi_items("CUSL", 1:3)),
+    composite("Value",        multi_items("PERV", 1:2)),
+    higher_composite("Nick", dimensions = c("Quality","Loyalty"), method = two_stage, weights = mode_B),
+    composite("Satisfaction", multi_items("CUSA", 1:3))
+  )
+
+  # Creating structural model
+  # - note, multiple paths can be created in each line
+  mobi_sm <- relationships(
+    paths(to = "Satisfaction",
+          from = c("Expectation", "Value","Nick"))
+  )
+
+  # Estimate the model with the HOC
+  model <- estimate_pls(data = mobi,
+                        measurement_model = mobi_mm,
+                        structural_model = mobi_sm)
+  # FAILS
+  testthat::expect_error(dot_graph(model), NA)
+  testthat::expect_error(plot(model), NA)
+  plot <- plot(model, structure_only = TRUE)
+
+
+})


### PR DESCRIPTION
Addresses issue #275 and also reported on facebook. Added a test.
This bugfix allows users to specify multiple constructs in the mm which do not occur in the sm when plotting. 
