### PR TITLE
Plspredict warnings

### DIFF
--- a/R/estimate_pls.R
+++ b/R/estimate_pls.R
@@ -170,13 +170,15 @@ estimate_pls <- function(data,
   if ( length(HOCs)>0 ) {
     # Append return list with first stage model and
     seminr_model$first_stage_model <- first_stage_model
-
+    seminr_model$hoc <- TRUE
     # Combine first and second stage measurement model matrices
     new_mm <- combine_first_order_second_order_matrices(model1 = first_stage_model, model2 = seminr_model, mmMatrix)
     seminr_model$outer_loadings <- new_mm$new_outer_loadings
     seminr_model$outer_weights <- new_mm$new_outer_weights
   }
-
+  if(length(processed_measurements$ints)>0) {
+    seminr_model$interaction <- TRUE
+  }
   class(seminr_model) <- c("pls_model", "seminr_model")
   return(seminr_model)
 }

--- a/R/feature_plspredict.R
+++ b/R/feature_plspredict.R
@@ -3,6 +3,16 @@
 predict.seminr_model <- function(object, testData, technique = predict_DA, na.print=".", digits=3, ...){
   stopifnot(inherits(object, "seminr_model"))
 
+  # Abort if received a higher-order-model or moderated model
+  if (!is.null(object$hoc)) {
+    message("There is no published solution for applying PLSpredict to higher-order-models")
+    return()
+  }
+  if (!is.null(object$interaction)) {
+    message("There is no published solution for applying PLSpredict to moderated models")
+    return()
+  }
+
   #Extract Measurements needed for Predictions
   normData <- testData[,object$mmVariables]
 
@@ -112,7 +122,15 @@ predict.seminr_model <- function(object, testData, technique = predict_DA, na.pr
 predict_pls <- function(model, technique = predict_DA, noFolds = NULL, reps = NULL, cores = NULL) {
 
   stopifnot(inherits(model, "seminr_model"))
-
+  # Abort if received a higher-order-model or moderated model
+  if (!is.null(model$hoc)) {
+    message("There is no published solution for applying PLSpredict to higher-order-models")
+    return()
+  }
+  if (!is.null(model$interaction)) {
+    message("There is no published solution for applying PLSpredict to moderated models")
+    return()
+  }
   # Get endogenous item names
   endogenous_items <- unlist(sapply(unique(model$smMatrix[,2]), function(x) model$mmMatrix[model$mmMatrix[, "construct"] == x,"measurement"]), use.names = FALSE)
 

--- a/R/plot_dot.R
+++ b/R/plot_dot.R
@@ -340,9 +340,12 @@ dot_graph.measurement_model <-
   as.data.frame(mm) -> mmodel
 
   hocs <- model$higher_order_composite
-  hocs
+
   a_model <- list(measurement_model = model,
                 mmMatrix = mm,
+                smMatrix = matrix(rep(unique(mmodel$construct),2),
+                                  ncol = 2,
+                                  nrow = length(unique(mmodel$construct))),
                 outer_weights = matrix(c(1), # add only 1s
                                        ncol = length(unique(mmodel$construct) ),
                                        dimnames = list(unique(mmodel$measurement),
@@ -358,11 +361,13 @@ dot_graph.measurement_model <-
                 constructs = unique(mmodel$construct),
                 mmVariables = unique(mmodel$measurement)
   )
-
+  if (length(hocs) > 0) {
+    a_model$hoc <- TRUE
+  }
   class(a_model) <- "pls_model"
 
 
-  # adjust themes to correct for aritifical information
+  # adjust themes to correct for artifical information
   thm$mm.edge.width_multiplier <- 1
   thm$mm.edge.label.show <- FALSE
   dot_graph(a_model, title = title, theme = thm, measurement_only = TRUE)
@@ -1206,8 +1211,8 @@ dot_component_mm <- function(model, theme) {
                                 "// ---------------------\n"))
 
   # we use mmMatrix because model$constructs does not contain HOCs
-  if (is.null(model$first_stage_model)) {
-    mm_count <- length(unique(model$mmMatrix[,1 ]))
+  if (is.null(model$hoc)) {
+    mm_count <- length(intersect(unique(model$smMatrix),unique(model$mmMatrix[,1 ])))
   } else {
     mm_count <- length(intersect(unique(c(model$smMatrix, model$first_stage_model$smMatrix)),unique(model$mmMatrix[,1 ])))
   }
@@ -1283,8 +1288,8 @@ extract_mm_coding <- function(model) {
   construct_types <- c()
 
   # iterate over all constructs in the mmMatrix
-  if (is.null(model$first_stage_model)) {
-    for (construct in unique(model$mmMatrix[,1 ])) {
+  if (is.null(model$hoc)) {
+    for (construct in model$constructs) {
       construct_names <- c(construct_names, construct)
       construct_types <- c(construct_types, get_construct_type(model, construct))
     }


### PR DESCRIPTION
Added two warnings for when users try to use predict.pls_model or predict_pls() on a model including a hoc or moderator. Returns NULL and throws a message. 