### PR TITLE
Function boot_paths_df (not exported) to return all path bootstraps as a long df

### DIFF
--- a/R/boot_utils.R
+++ b/R/boot_utils.R
@@ -1,0 +1,15 @@
+#' Return all path bootstraps as a long table
+#'
+#' @param pls_boot bootstrapped PLS model
+boot_paths_df <- function(pls_boot) {
+  path_names <- apply(pls_boot$smMatrix, 1, \(path) {
+    paste(path['source'], '->', path['target'])
+  })
+
+  boot_paths <- apply(pls_boot$smMatrix, 1, \(path) {
+    pls_boot$boot_paths[path['source'], path['target'], 1:pls_boot$boots]
+  })
+
+  colnames(boot_paths) <- path_names
+  boot_paths
+}

--- a/R/estimate_pls_mga.R
+++ b/R/estimate_pls_mga.R
@@ -50,12 +50,6 @@ estimate_pls_mga <- function(pls_model, condition, nboot = 2000, ...) {
     path_coef[path["source"], path["target"]]
   }
 
-  # Get all path estimates of a given beta metrix from a given path_coef matrix
-  # Typically used to apply on 3rd dimension of a 3x3 bootstrap paths array [from,to,boot]
-  boot_paths <- function(path_coef, beta_df) {
-    betas <- apply(beta_df, MARGIN=1, FUN=path_estimate, path_coef = path_coef)
-  }
-
   # Allocate and Estimate Two Alternative Datasets + Models
   group1_data <- pls_data[condition, ]
   group2_data <- pls_data[!condition, ]
@@ -82,11 +76,8 @@ estimate_pls_mga <- function(pls_model, condition, nboot = 2000, ...) {
   beta$diff <- apply(beta, MARGIN = 1, FUN=path_estimate, path_coef = beta_diff)
 
   # Get bootstrapped paths for both groups
-  boot1_betas <- t(apply(group1_boot$boot_paths, MARGIN=3, FUN=boot_paths, beta_df=beta))
-  colnames(boot1_betas) <- path_names
-
-  boot2_betas <- t(apply(group2_boot$boot_paths, MARGIN=3, FUN=boot_paths, beta_df=beta))
-  colnames(boot2_betas) <- path_names
+  boot1_betas <- boot_paths_df(group1_boot)
+  boot2_betas <- boot_paths_df(group2_boot)
 
   # PLSc may not resolve in some bootstrap runs - limit bootstrap paths to resolved number of boots
   J <- min(dim(boot1_betas)[1], dim(boot2_betas)[1])


### PR DESCRIPTION
- R/boot_utils.R: added function boot_paths_df
- R/estimate_pls_mga.R: refactored to use boot_paths_df in lieu of earlier implementation

note: boot_paths_df might be helpful for other tasks such as moderated mediation (see email w/Fawad)