### PR TITLE
fix #333: Cross-Validation fails when using a tibble

### DIFF
--- a/R/feature_plspredict.R
+++ b/R/feature_plspredict.R
@@ -174,10 +174,10 @@ predict_pls <- function(model, technique = predict_DA, noFolds = NULL, reps = NU
                   lm_out_of_sample = LM_predicted_outsample_item,
                   lm_in_sample = LM_predicted_insample_item,
                   item_actuals = ordered_data[as.character(c(1:nrow(model$data))),model$mmVariables],
-                  PLS_out_of_sample_residuals = (ordered_data[as.character(c(1:nrow(model$data))),endogenous_items] - PLS_predicted_outsample_item[,endogenous_items]),
-                  PLS_in_sample_residuals = (ordered_data[as.character(c(1:nrow(model$data))),endogenous_items] - PLS_predicted_insample_item[,endogenous_items]),
-                  lm_out_of_sample_residuals = (ordered_data[as.character(c(1:nrow(model$data))),endogenous_items] - LM_predicted_outsample_item),
-                  lm_in_sample_residuals = (ordered_data[as.character(c(1:nrow(model$data))),endogenous_items] - LM_predicted_insample_item))
+                  PLS_out_of_sample_residuals = (ordered_data[as.character(c(1:nrow(model$data))),as.vector(endogenous_items)] - PLS_predicted_outsample_item[,endogenous_items]),
+                  PLS_in_sample_residuals = (ordered_data[as.character(c(1:nrow(model$data))),as.vector(endogenous_items)] - PLS_predicted_insample_item[,endogenous_items]),
+                  lm_out_of_sample_residuals = (ordered_data[as.character(c(1:nrow(model$data))),as.vector(endogenous_items)] - LM_predicted_outsample_item),
+                  lm_in_sample_residuals = (ordered_data[as.character(c(1:nrow(model$data))),as.vector(endogenous_items)] - LM_predicted_insample_item))
   class(results) <- "predict_pls_model"
   return(results)
 }
@@ -336,7 +336,7 @@ in_and_out_sample_predictions <- function(x, folds, ordered_data, model,techniqu
   # collect the odd and even numbered matrices from the matrices return object
   lmprediction_in_sample <- do.call(cbind, lm_holder[((1:(length(unique(model$smMatrix[,2]))*2))[1:(length(unique(model$smMatrix[,2]))*2)%%2==1])])
   lmprediction_out_sample <- do.call(cbind, lm_holder[((1:(length(unique(model$smMatrix[,2]))*2))[1:(length(unique(model$smMatrix[,2]))*2)%%2==0])])
-  lmprediction_in_sample_residuals[trainIndexes,] <- as.matrix(ordered_data[trainIndexes,endogenous_items]) - lmprediction_in_sample[trainIndexes,endogenous_items]
+  lmprediction_in_sample_residuals[trainIndexes,] <- as.matrix(ordered_data[trainIndexes,as.vector(endogenous_items)]) - lmprediction_in_sample[trainIndexes,as.vector(endogenous_items)]
 
   return(list(PLS_predicted_insample_item = PLS_predicted_insample_item,
               PLS_predicted_outsample_item = PLS_predicted_outsample_item,


### PR DESCRIPTION
predict_pls uses a matrix with variable names to subset the data set. This works with data.frames, but not with tibbles, which results in the error reported in issue #333. This fix addresses the issue by first casting the matrix to a vector when subsetting the data.

Example:

```
library(seminr)
mobi_mm <- constructs(
  composite("Image",        multi_items("IMAG", 1:5)),
  composite("Expectation",  multi_items("CUEX", 1:3)),
  composite("Value",        multi_items("PERV", 1:2)),
  composite("Satisfaction", multi_items("CUSA", 1:3))
)

mobi_sm <- relationships(
  paths(to = "Satisfaction",
        from = c("Image", "Expectation", "Value"))
)

mobi_pls <- estimate_pls(mobi, mobi_mm, mobi_sm)
cross_validated_predictions <- predict_pls(model = mobi_pls,
                                           technique = predict_DA,
                                           noFolds = 10,
                                           cores = NULL)
# The following fails in the current version of seminr:
mobi_pls <- estimate_pls(tibble::as_tibble(mobi), mobi_mm, mobi_sm)
cross_validated_predictions_tibble <- predict_pls(model = mobi_pls,
                                                  technique = predict_DA,
                                                  noFolds = 10,
                                                  cores = NULL)
```