### PR TITLE
fix: correctly relabel lavaan summary output column as p-value

### DIFF
--- a/R/report_lavaan.R
+++ b/R/report_lavaan.R
@@ -15,9 +15,9 @@ summarize_cb_measurement <- function(object, alpha=0.05) {
                                     model$item_names, model$construct_names)
   alpha_text <- alpha/2*100
   significance <- with(loadings_df,
-                       data.frame(est.std, se, pvalue, ci.lower, ci.upper))
+                       data.frame(est.std, se, z, pvalue, ci.lower, ci.upper))
   rownames(significance) <- with(loadings_df, paste(lhs, "->", rhs))
-  colnames(significance) <- c( "Std Estimate", "SE", "t-Value", paste(alpha_text, "% CI", sep = ""), paste((100-alpha_text), "% CI", sep = ""))
+  colnames(significance) <- c( "Std Estimate", "SE", "z-Value", "p-Value", paste(alpha_text, "% CI", sep = ""), paste((100-alpha_text), "% CI", sep = ""))
 
   # Get descriptives and correlations
   available_item_names <- intersect(names(object$data), model$item_names)


### PR DESCRIPTION
Fixes an issue emailed in to me: summary of CFA (lavaan) results were being misreported: p-values reported as t-values. Now, both t-values (technically, z-values) and p-values reported distinctly in summary table.